### PR TITLE
Update pwm_tester.py

### DIFF
--- a/src/raccoonlab_tools/scripts/dronecan/pwm_tester/pwm_tester.py
+++ b/src/raccoonlab_tools/scripts/dronecan/pwm_tester/pwm_tester.py
@@ -72,8 +72,8 @@ class PWMActuatorCommander:
                 self.node.broadcast(self.command)
                 print("Pub ARRAYCommand")
                 for i in range(PWMActuatorCommander.NUMBER_OF_PWM):
-                    self.expected_status_msg = uavcan.equipment.esc.Status(
-                        esc_index=i,
+                    self.expected_status_msg = uavcan.equipment.actuator.Status(
+                        actuator_id=i,
                         power_rating_pct=int(expected_status_vals[i])
                     )
                     self.node.broadcast(self.expected_status_msg)

--- a/src/raccoonlab_tools/scripts/dronecan/pwm_tester/pwm_tester.py
+++ b/src/raccoonlab_tools/scripts/dronecan/pwm_tester/pwm_tester.py
@@ -127,7 +127,7 @@ class PWMEscCommander:
                      for val in command]
             )
             for i in range(PWMEscCommander.NUMBER_OF_PWM):
-                expected_status_vals[i] = 100 * (command[i] + 1)
+                expected_status_vals[i] = 50 * (command[i] + 1)
 
             self.node.spin(0.5)
             if len(self.online_nodes) >= 1:


### PR DESCRIPTION
Fix bug for esc.Status expected power_rating_pct value
Since the value generator is sinusoid with range [-1, 1], to convert the value to ptc, we add 1 and then the values range becomes [0, 2], therefore the ptc scaler should be 50, not 100.

Also changed the status message for Actuator commander from esc.Status to acturator.Status - since the Dronecan lib has been changed, so actuator.Status became available