### PR TITLE
fix mutable default values for fields in a dataclass

### DIFF
--- a/src/raccoonlab_tools/common/node.py
+++ b/src/raccoonlab_tools/common/node.py
@@ -2,7 +2,7 @@
 # This software is distributed under the terms of the MIT License.
 # Copyright (c) 2024 Dmitry Ponomarev.
 # Author: Dmitry Ponomarev <ponomarevda96@gmail.com>
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from binascii import hexlify
 from raccoonlab_tools.common.colorizer import Colors
 
@@ -33,8 +33,9 @@ class NodeInfo:
     """
     node_id : int
     name : str
-    software_version : SoftwareVersion = SoftwareVersion()
-    hardware_version : HardwareVersion = HardwareVersion()
+    software_version: SoftwareVersion = field(default_factory=SoftwareVersion)
+    hardware_version: HardwareVersion = field(default_factory=HardwareVersion)
+
 
     @staticmethod
     def create_from_cyphal_response(transfer : tuple):


### PR DESCRIPTION
In Python's dataclasses, mutable default values (like a list or an instance of another dataclass) should be assigned using default_factory to prevent all instances of the class from sharing the same mutable object.

![image](https://github.com/user-attachments/assets/44cfc421-1bf8-468d-a5d8-d37c489e1711)
