### PR TITLE
add simple can interface without sniffer

### DIFF
--- a/src/raccoonlab_tools/common/device_manager.py
+++ b/src/raccoonlab_tools/common/device_manager.py
@@ -41,7 +41,7 @@ class DeviceManager:
         system = platform.system()
         if system == "Linux":
             for interface in netifaces.interfaces():
-                if interface.startswith("slcan"):
+                if interface.startswith(("slcan", "can")):
                     transports.append(CanInterface(port=interface))
 
         for port, desc, hwid in sorted(serial.tools.list_ports.comports()):

--- a/src/raccoonlab_tools/dronecan/global_node.py
+++ b/src/raccoonlab_tools/dronecan/global_node.py
@@ -14,7 +14,7 @@ class DronecanNode:
     def __init__(self, node_id: int = 100) -> None:
         if DronecanNode.node is None:
             transport = DeviceManager.get_device_port()
-            if transport.startswith("slcan"):
+            if transport.startswith(("slcan", "can")):
                 dronecan_transport = f'{transport}'
             elif transport.startswith("/dev/") or transport.startswith("COM"):
                 dronecan_transport = f'slcan:{transport}'


### PR DESCRIPTION
Change: Updated the logic for identifying CAN interfaces. The code now includes both "slcan" and "can" interfaces when searching for available transport interfaces. This change allows for direct connection to CAN interfaces, in addition to those using the slcan protocol.

These changes enhance the flexibility of the system by allowing connections to be established directly via CAN interfaces, which is useful in scenarios where the CAN interface is emulated through SPI and sniffer tools are not used.